### PR TITLE
Update hackage-shield version

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ To use this library for testing, just add it to a test stanza of your cabal file
 To use this library to export your own `Laws` functions which you wish to distribute, add it to the library stanza of your cabal file.
 
   [hackage]: http://hackage.haskell.org/package/hedgehog-classes
-  [hackage-shield]: https://img.shields.io/badge/hackage-v0.1.1.0-blue.svg
+  [hackage-shield]: https://img.shields.io/badge/hackage-v0.2.4.1-blue.svg
 
 ## Improvements
 


### PR DESCRIPTION
https://img.shields.io/hackage/v/hedgehog-classes.svg?style=flat ought to work, but it doesn't. Perhaps the `version` field needs to be moved to the top in `hedgehog-classes.cabal` :thinking: 
