### PR TITLE
Bumps semirings upper bound

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -166,7 +166,7 @@ library
 --    build-depends: semigroupoids >= 0.5.3.0 && < 0.6.0.0
 --    cpp-options: -DHAVE_SEMIGROUPOIDS
   if flag(semirings)
-    build-depends: semirings >= 0.2 && < 0.6
+    build-depends: semirings >= 0.2 && < 0.7
     cpp-options: -DHAVE_SEMIRINGS
   if flag(comonad)
     build-depends: comonad >= 5.0 && < 5.1


### PR DESCRIPTION
Addresses https://github.com/commercialhaskell/stackage/issues/5816; I've verified that `hedgehog-classes` compiles and tests pass (locally) with `semirings-0.6`.