### PR TITLE
Read from the actual byte offset in 'storablePeekByte'

### DIFF
--- a/test/Spec/Storable.hs
+++ b/test/Spec/Storable.hs
@@ -1,5 +1,11 @@
 module Spec.Storable (testStorable) where
 
+import Foreign.C.String (CString, newCString, peekCString)
+import Foreign.C.Types (CInt)
+import Foreign.Ptr (nullPtr, castPtr, plusPtr, minusPtr, alignPtr)
+import Foreign.Storable (Storable, sizeOf, alignment, peek, peekByteOff, poke, pokeByteOff)
+
+import Hedgehog (Gen)
 import Hedgehog.Classes
 
 import qualified Hedgehog.Gen as Gen
@@ -17,6 +23,7 @@ testStorable =
   , ("Word16", lawsWord16)
   , ("Word32", lawsWord32)
   , ("Word64", lawsWord64)
+  , ("complex struct", lawsStruct)
   ]
 
 ranged :: (Bounded a, Num a) => (Range.Range a -> b) -> b
@@ -35,3 +42,39 @@ lawsWord8 = [storableLaws (ranged Gen.word8)]
 lawsWord16 = [storableLaws (ranged Gen.word16)]
 lawsWord32 = [storableLaws (ranged Gen.word32)]
 lawsWord64 = [storableLaws (ranged Gen.word64)]
+
+lawsStruct :: [Laws]
+lawsStruct = [storableLaws genStruct]
+
+genStruct :: Gen TestStruct
+genStruct = TestStruct
+    <$> fmap fromIntegral (Gen.integral Range.linearBounded :: Gen CInt)
+    <*> Gen.string (Range.linear 0 16) (Gen.filter (/= '\NUL') Gen.latin1)
+
+data TestStruct = TestStruct
+    { testPadding :: Int
+    , testString :: String
+    }
+  deriving (Eq, Show)
+instance Storable TestStruct where
+    sizeOf _ = offsetTest + (sizeOf (undefined :: Int) `max` sizeOf (undefined :: CString))
+    alignment _ = alignment (undefined :: Int) `lcm` alignment (undefined :: CString)
+    peek ptr = do
+        pad <- peek $ castPtr ptr
+        strPtr <- peekByteOff ptr offsetTest
+        str <- if strPtr == nullPtr
+            then return ""
+            else peekCString strPtr
+        return $ TestStruct
+            { testPadding = pad
+            , testString = str
+            }
+    poke ptr x = do
+        poke (castPtr ptr) $ testPadding x
+        strPtr <- newCString $ testString x
+        pokeByteOff ptr offsetTest strPtr
+
+offsetTest :: Int
+offsetTest = (nullPtr `plusPtr` sizeOf int) `alignPtr` alignment string `minusPtr` nullPtr
+  where int = undefined :: Int
+        string = undefined :: CString


### PR DESCRIPTION
Fixes #36.  The `TestStruct` instance did indeed crash as described in that issue before the fix was applied.  The exact calculation used for `off` will still run into issues with `Storable` instances where `sizeOf` (or, even less commonly, `alignment`) changes depending on the data, but there's an argument to be made that any such instance is poorly-written to begin with, and uncommon enough that the cost in complexity outweighs the benefits.  For the record, a complete fix would require something like the following (untested):

```haskell
foldl' (\ptr a -> (ptr `alignPtr` alignment a) `plusPtr` sizeOf a) nullPtr (take (max 0 $ ix - 1) as) `alignPtr` (as !! ix) `minusPtr` nullPtr
```