### PR TITLE
Update base bounds to support GHC 9.0.1

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -40,6 +40,7 @@ tested-with:
     GHC == 8.6.5
   , GHC == 8.8.3
   , GHC == 8.10.1
+  , GHC == 9.0.1
 
 source-repository head
   type:
@@ -147,7 +148,7 @@ library
     Hedgehog.Classes.Storable
     Hedgehog.Classes.Traversable
   build-depends:
-    , base >= 4.12 && < 4.15
+    , base >= 4.12 && < 4.16
     , binary >= 0.8 && < 0.9
     , containers >= 0.5 && < 0.7
     , hedgehog >= 1 && < 1.1


### PR DESCRIPTION
Everything builds and the test suite passes, so this should be safe.  Hackage will still need a revision bump; there's probably not enough changes for even a patch release.