### PR TITLE
Make the corresponding modules empty when aeson and primitive flags are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 `hedgehog-classes` uses [PVP Versioning][1].
 The changelog is available [on GitHub][2].
 
+Unreleased
+=======
+* Make `Hedgehog.Classes.Aeson` module empty when the `aeson` flag is disabled.
+* Make `Hedgehog.Classes.Prim` module empty when the `primitive` flag is disabled.
+
 0.2.5.3
 =======
 * Correct bug in which `storablePeekByte` uses the wrong offset values

--- a/src/Hedgehog/Classes/Json.hs
+++ b/src/Hedgehog/Classes/Json.hs
@@ -1,4 +1,11 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+
+#ifndef HAVE_AESON
+
+module Hedgehog.Classes.Json () where
+
+#else
 
 module Hedgehog.Classes.Json (jsonLaws) where
 
@@ -35,7 +42,7 @@ jsonEncodingPartialIsomorphism gen = property $ do
               , "encode x = " ++ showEncoded
               ]
         , lawContextReduced = reduced lhs rhs
-        }  
+        }
   heqCtx lhs rhs ctx
 
 jsonEncodingEqualsValue :: forall a. (ToJSON a, Show a) => Gen a -> Property
@@ -58,7 +65,8 @@ jsonEncodingEqualsValue gen = property $ do
               , "encoded = " ++ showEncoded
               , "decoded = " ++ showDecoded
               ]
-        , lawContextReduced = reduced lhs rhs 
+        , lawContextReduced = reduced lhs rhs
         }
-  heqCtx lhs rhs ctx 
+  heqCtx lhs rhs ctx
 
+#endif

--- a/src/Hedgehog/Classes/Prim.hs
+++ b/src/Hedgehog/Classes/Prim.hs
@@ -1,9 +1,16 @@
+{-# language CPP #-}
 {-# language LambdaCase #-}
 {-# language UnboxedTuples #-}
 {-# language TypeApplications #-}
 {-# language MagicHash #-}
 {-# language BangPatterns #-}
 {-# language ScopedTypeVariables #-}
+
+#ifndef HAVE_PRIMITIVE
+
+module Hedgehog.Classes.Prim () where
+
+#else
 
 module Hedgehog.Classes.Prim (primLaws) where
 
@@ -257,3 +264,4 @@ primListRoundtripAddr gen = property $ do
     ptrToList 0
   xs === xs'
 
+#endif


### PR DESCRIPTION
Without this patch I see errors like the below one when I build `hedgehog-classes` with all flags disabled:

```
[29 of 44] Compiling Hedgehog.Classes.Json ( src/Hedgehog/Classes/Json.hs, dist/build/Hedgehog/Classes/Json.o, dist/build/Hedgehog/Classes/Json.dyn_o )

src/Hedgehog/Classes/Json.hs:7:1: error:
    Could not load module ‘Data.Aeson’
    It is a member of the hidden package ‘aeson-2.0.2.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.2.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-2.0.2.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-1.5.6.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-1.5.6.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    It is a member of the hidden package ‘aeson-1.5.6.0’.
    Perhaps you need to add ‘aeson’ to the build-depends in your .cabal file.
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
  |
7 | import Data.Aeson (FromJSON, ToJSON(toJSON))
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```