### PR TITLE
Support `hedgehog-1.1`

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -151,7 +151,7 @@ library
     , base >= 4.12 && < 4.17
     , binary >= 0.8 && < 0.9
     , containers >= 0.5 && < 0.7
-    , hedgehog >= 1 && < 1.1
+    , hedgehog >= 1 && < 1.2
     , pretty-show >= 1.9 && < 1.11
     , silently >= 1.2 && < 1.3
     , transformers >= 0.5 && < 0.6


### PR DESCRIPTION
Confirmed to build OK when using `allow-newer`.