### PR TITLE
Allow building with `base-4.17` and `vector-0.13`

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -148,7 +148,7 @@ library
     Hedgehog.Classes.Storable
     Hedgehog.Classes.Traversable
   build-depends:
-    , base >= 4.12 && < 4.17
+    , base >= 4.12 && < 4.18
     , binary >= 0.8 && < 0.9
     , containers >= 0.5 && < 0.7
     , hedgehog >= 1 && < 1.2
@@ -173,7 +173,7 @@ library
     build-depends: comonad >= 5.0 && < 5.1
     cpp-options: -DHAVE_COMONAD
   if flag(vector)
-    build-depends: vector >= 0.12 && < 0.13
+    build-depends: vector >= 0.12 && < 0.14
     cpp-options: -DHAVE_VECTOR
   if flag(primitive)
     build-depends: primitive >= 0.6.4 && < 0.8


### PR DESCRIPTION
I noticed these when trying to make `hedgehog-classes` build with GHC 9.4.