### PR TITLE
Bump upper version bounds for GHC 9.6

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -150,13 +150,13 @@ library
     Hedgehog.Classes.Storable
     Hedgehog.Classes.Traversable
   build-depends:
-    , base >= 4.12 && < 4.18
+    , base >= 4.12 && < 4.19
     , binary >= 0.8 && < 0.9
     , containers >= 0.5 && < 0.7
     , hedgehog >= 1 && < 1.3
     , pretty-show >= 1.9 && < 1.11
     , silently >= 1.2 && < 1.3
-    , transformers >= 0.5 && < 0.6
+    , transformers >= 0.5 && < 0.7
     , wl-pprint-annotated >= 0.0 && < 0.2
   ghc-options:
     -Wall
@@ -178,7 +178,7 @@ library
     build-depends: vector >= 0.12 && < 0.14
     cpp-options: -DHAVE_VECTOR
   if flag(primitive)
-    build-depends: primitive >= 0.6.4 && < 0.8
+    build-depends: primitive >= 0.6.4 && < 0.9
     cpp-options: -DHAVE_PRIMITIVE
 
 test-suite spec

--- a/src/Hedgehog/Classes/Applicative.hs
+++ b/src/Hedgehog/Classes/Applicative.hs
@@ -4,7 +4,7 @@
 
 module Hedgehog.Classes.Applicative (applicativeLaws) where
 
-import Control.Applicative (Applicative(..))
+import qualified Control.Applicative as App (liftA2)
 
 import Hedgehog
 import Hedgehog.Classes.Common
@@ -15,8 +15,8 @@ import Hedgehog.Classes.Common
 -- [__Composition__]: @'pure' ('.') '<*>' u '<*>' v '<*>' w@ ≡ @u '<*>' (v '<*>' w)@
 -- [__Homomorphism__]: @'pure' f '<*>' 'pure'@ x ≡ @'pure' (f x)@
 -- [__Interchange__]: @u '<*>' 'pure' y@ ≡ @'pure' ('$' y) '<*>' u@
--- [__LiftA2 1__]: @'liftA2' 'id' f x@ ≡ @f '<*>' x@
--- [__LiftA2 2__]: @'liftA2' f x y@ ≡ @f '<$>' x '<*>' y@
+-- [__LiftA2 1__]: @'App.liftA2' 'id' f x@ ≡ @f '<*>' x@
+-- [__LiftA2 2__]: @'App.liftA2' f x y@ ≡ @f '<$>' x '<*>' y@
 applicativeLaws ::
   ( Applicative f
   , forall x. Eq x => Eq (f x), forall x. Show x => Show (f x)
@@ -27,7 +27,7 @@ applicativeLaws gen = Laws "Applicative"
   , ("Homomorphism", applicativeHomomorphism gen)
   , ("Interchange", applicativeInterchange gen)
   , ("LiftA2 Part 1", applicativeLiftA2_1 gen)
-  , ("LiftA2 Part 2", applicativeLiftA2_2 gen) 
+  , ("LiftA2 Part 2", applicativeLiftA2_2 gen)
   ]
 
 type ApplicativeProp f =
@@ -122,7 +122,7 @@ applicativeLiftA2_1 fgen = property $ do
   f' <- forAll $ fgen genQuadraticEquation
   x <- forAll $ fgen genSmallInteger
   let f = fmap runQuadraticEquation f'
-  let lhs = liftA2 id f x
+  let lhs = App.liftA2 id f x
   let rhs = f <*> x
   let ctx = contextualise $ LawContext
         { lawContextLawName = "LiftA2 1", lawContextLawBody = "liftA2 id f x" `congruency` "f <*> x"
@@ -143,7 +143,7 @@ applicativeLiftA2_2 fgen = property $ do
   y <- forAll $ fgen genSmallInteger
   f' <- forAll $ genLinearEquationTwo
   let f = runLinearEquationTwo f'
-  let lhs = liftA2 f x y
+  let lhs = App.liftA2 f x y
   let rhs = f <$> x <*> y
   let ctx = contextualise $ LawContext
         { lawContextLawName = "LiftA2 2", lawContextLawBody = "liftA2 f x y == f <$> x <*> y"

--- a/test/Spec/Comonad.hs
+++ b/test/Spec/Comonad.hs
@@ -10,7 +10,7 @@ module Spec.Comonad
   ) where
 
 import Data.List.NonEmpty
-import Control.Applicative (liftA2)
+import qualified Control.Applicative as App (liftA2)
 import Control.Comonad
 import Control.Comonad.Store hiding (store)
 import Data.Functor.Identity (Identity(..))
@@ -43,7 +43,7 @@ identity :: MonadGen m => m a -> m (Identity a)
 identity = fmap Identity
 
 nonempty :: MonadGen m => m a -> m (NonEmpty a)
-nonempty gen = liftA2 (:|) gen (list gen)
+nonempty gen = App.liftA2 (:|) gen (list gen)
 
 tup :: MonadGen m => m a -> m (Integer, a)
 tup gen = (,)

--- a/test/Spec/Monad.hs
+++ b/test/Spec/Monad.hs
@@ -10,7 +10,8 @@ module Spec.Monad
   , testMonadZip
   ) where
 
-import Control.Applicative (Alternative(..), liftA2)
+import qualified Control.Applicative as App (liftA2)
+import Control.Applicative (Alternative(..))
 import Control.Monad.IO.Class (MonadIO(..))
 
 import Data.Functor.Identity (Identity(..))
@@ -106,7 +107,7 @@ newtype TestIO a = TestIO (IO a)
 
 -- | Unsafe!
 instance Eq a => Eq (TestIO a) where
-  TestIO a == TestIO b = unsafePerformIO $ liftA2 (==) a b
+  TestIO a == TestIO b = unsafePerformIO $ App.liftA2 (==) a b
   {-# noinline (==) #-}
 -- | Unsafe!
 instance Show a => Show (TestIO a) where


### PR DESCRIPTION
Because GHC 9.6 adds `liftA2` to the `Prelude`, I also qualified every import of `liftA2` to avoid `-Wredundant-imports` warning when building with GHC 9.6.