### PR TITLE
eqLaws: Use "Reflexivity", "Symmetry" and "Transitivity"

### DIFF
--- a/src/Hedgehog/Classes/Eq.hs
+++ b/src/Hedgehog/Classes/Eq.hs
@@ -13,9 +13,9 @@ import Hedgehog.Classes.Common
 -- [__Negation__]: @x '/=' y@ ≡ @'not' (x '==' y)@
 eqLaws :: (Eq a, Show a) => Gen a -> Laws
 eqLaws gen = Laws "Eq"
-  [ ("Transitive", eqTransitive gen)
-  , ("Symmetric", eqSymmetric gen)  
-  , ("Reflexive", eqReflexive gen) 
+  [ ("Transitivity", eqTransitive gen)
+  , ("Symmetry", eqSymmetric gen)  
+  , ("Reflexivity", eqReflexive gen) 
   , ("Negation", eqNegation gen) 
   ]
 


### PR DESCRIPTION
instead of "Reflexive", "Symmetric" and "Transitive".

This is consistent with how `semigroupLaws` and `monoidLaws` use "Associativity" and "Identity".

It is also consistent with the terminology used in the Haddocks of `base`: https://hackage.haskell.org/package/base-4.19.0.0/docs/Data-Eq.html#t:Eq

My practical motivation for this change is that it will make the output for `hspec` consistent and grammatically correct. (see https://github.com/hedgehogqa/haskell-hedgehog-classes/issues/41#issuecomment-1807931945)