### PR TITLE
bump primitive

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -178,7 +178,7 @@ library
     build-depends: vector >= 0.12 && < 0.14
     cpp-options: -DHAVE_VECTOR
   if flag(primitive)
-    build-depends: primitive >= 0.6.4 && < 0.9
+    build-depends: primitive >= 0.6.4 && < 0.10
     cpp-options: -DHAVE_PRIMITIVE
 
 test-suite spec


### PR DESCRIPTION
0.9 is compatible with the current master.