### PR TITLE
Compatibility with newer dependencies

### DIFF
--- a/hedgehog-classes.cabal
+++ b/hedgehog-classes.cabal
@@ -150,10 +150,10 @@ library
     Hedgehog.Classes.Storable
     Hedgehog.Classes.Traversable
   build-depends:
-    , base >= 4.12 && < 4.20
+    , base >= 4.12 && < 4.21
     , binary >= 0.8 && < 0.9
-    , containers >= 0.5 && < 0.7
-    , hedgehog >= 1 && < 1.5
+    , containers >= 0.5 && < 0.8
+    , hedgehog >= 1 && < 1.6
     , pretty-show >= 1.9 && < 1.11
     , silently >= 1.2 && < 1.3
     , transformers >= 0.5 && < 0.7
@@ -178,7 +178,7 @@ library
     build-depends: vector >= 0.12 && < 0.14
     cpp-options: -DHAVE_VECTOR
   if flag(primitive)
-    build-depends: primitive >= 0.6.4 && < 0.9
+    build-depends: primitive >= 0.6.4 && < 0.10
     cpp-options: -DHAVE_PRIMITIVE
 
 test-suite spec


### PR DESCRIPTION
Tested using

    cabal test -w ghc-9.10.1 -c 'hedgehog>=1.5' -c 'primitive>=0.9'

which passes.
